### PR TITLE
Continue if report is missing

### DIFF
--- a/thoth/report_processing/components/adviser.py
+++ b/thoth/report_processing/components/adviser.py
@@ -192,6 +192,9 @@ class Adviser:
                     report = result.get("report")
                     general_error = result["error"]
 
+                    if not report:
+                        continue
+
                     for info in report["stack_info"]:
 
                         justification = {"message": info["message"], "type": info["type"]}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/advise-reporter/issues/149

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add check if the report in adviser is null and skip that document

