### PR TITLE
Use error msg in result when report is missing

### DIFF
--- a/thoth/report_processing/components/adviser.py
+++ b/thoth/report_processing/components/adviser.py
@@ -233,15 +233,17 @@ class Adviser:
                 _LOGGER.error("Adviser document %s report is: %s", document_id, report)
 
             if not report:
-                _LOGGER.warning(f"No report for adviser document: {document_id}")
+                _LOGGER.warning(f"No report for adviser document: {document_id}, checking error msg from document.")
+                error_msg = result["error_msg"]
+
                 justifications_collected.append(
                     {
                         "document_id": document_id,
                         "date": datetime_object,
                         "analyzer_version": analyzer_version,
-                        "justification": "no report provided",
+                        "justification": error_msg,
                         "error": True,
-                        "message": "no report provided",
+                        "message": error_msg,
                         "type": "ERROR",
                     },
                 )

--- a/thoth/report_processing/components/adviser.py
+++ b/thoth/report_processing/components/adviser.py
@@ -234,7 +234,7 @@ class Adviser:
 
             if not report:
                 _LOGGER.warning(f"No report for adviser document: {document_id}, checking error msg from document.")
-                error_msg = result["error_msg"]
+                error_msg = result.get("error_msg", "no report provided")
 
                 justifications_collected.append(
                     {


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

The error msg contains the justification for errors.

```
"result": {
    "error": true,
    "error_msg": "Resolver was killed as allocated CPU time was exceeded - https://thoth-station.ninja/j/cpu_time_exceeded",
    "parameters": {
      "beam_width": 25000,
      "count": 1,
      "dev": false,
      "library_usage": null,
      "limit": 1,
      "limit_latest_versions": -1,
      "no_pretty": false,
      "output": "/mnt/workdir/adviser-210420005338-6c5c4ad2b5cd9ff7",
      "pipeline": null,
      "plot": null,
      "predictor": "AUTO",
      "predictor_config": "{}",
      "prescription": [
        "/mnt/workdir/prescription.yaml"
      ],
      "project": {
        "requirements": {
          "dev-packages": {},
          "packages": {
            "flask": "*"
          },
          "requires": {
            "python_version": "3.6"
          },
          "source": [
            {
              "name": "pypi-org",
              "url": "https://pypi.org/simple",
              "verify_ssl": true
            }
          ]
        },
        "requirements_locked": null,
        "runtime_environment": {
          "base_image": null,
          "cuda_version": null,
          "cudnn_version": null,
          "hardware": {
            "cpu_family": null,
            "cpu_model": null,
            "gpu_model": null
          },
          "mkl_version": null,
          "name": "rhel",
          "openblas_version": null,
          "openmpi_version": null,
          "operating_system": {
            "name": "rhel",
            "version": "8.0"
          },
          "platform": null,
          "python_version": "3.6",
          "recommendation_type": null
        }
      },
      "recommendation_type": "latest",
      "requirements": "input/Pipfile",
      "requirements_format": "pipenv",
      "requirements_locked": "input/Pipfile.lock",
      "runtime_environment": "input/runtime_environment.json",
      "seed": 42,
      "user_stack_scoring": true
    },
    "report": null
  }

```
