### PR TITLE
Fix missing tab in inspection.py

### DIFF
--- a/thoth/report_processing/components/inspection.py
+++ b/thoth/report_processing/components/inspection.py
@@ -338,11 +338,11 @@ class AmunInspections:
                         if not os.path.exists(result_path):
                             os.makedirs(result_path)
 
-                    with open(
-                        f"{store_locally_repo_name}/{inspection_document_id}/results/{inspection_result_number}/result",
-                        "w",
-                    ) as result_file:
-                        result_file.write(json.dumps(inspection_result_document))
+                        with open(
+                            f"{store_locally_repo_name}/{inspection_document_id}/results/{inspection_result_number}/result",
+                            "w",
+                        ) as result_file:
+                            result_file.write(json.dumps(inspection_result_document))
 
                 if store_files and ThothAmunInspectionFileStoreEnum.hardware_info.name in store_files:
                     inspection_hw_info = inspection_store.results.retrieve_hwinfo(


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [ x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Put the `with open(...` statement in [`inspection.py`](https://github.com/thoth-station/report-processing/blob/88abd70368ad8c700625bcd3ad61a8055611a78a/thoth/report_processing/components/inspection.py#L341) in the [`if` statement above](https://github.com/thoth-station/report-processing/blob/88abd70368ad8c700625bcd3ad61a8055611a78a/thoth/report_processing/components/inspection.py#L334) to store files locally only if specified.

## Description


