### PR TITLE
WIP Fix inspection.py to raise exceptions related to the content of datasets notebooks

### DIFF
--- a/thoth/report_processing/components/inspection.py
+++ b/thoth/report_processing/components/inspection.py
@@ -565,7 +565,11 @@ class AmunInspections:
     @staticmethod
     def _parse_requirements_locked(requirements_locked: Dict[str, Any]) -> Dict[str, Any]:
         """Parse requirements_locked to make sure name, version, index is present."""
-        default = requirements_locked["default"]
+        try:
+            default = requirements_locked["default"]
+        except KeyError:
+            raise KeyError
+
         for package_name, data in default.items():
 
             # Use PyPI index as default if index is missing


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/datasets/issues/53

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Raise exceptions when the content of the files retrieved from Ceph do not match the implementation of the notebooks from the `datasets` repository.
