### PR TITLE
Fix key error for create_inspections_dataframe

### DIFF
--- a/thoth/report_processing/components/inspection.py
+++ b/thoth/report_processing/components/inspection.py
@@ -753,7 +753,7 @@ class AmunInspections:
                     extracted_columns.append(column)
 
             flags_dict = {}
-            for flags in dataframe["__hwinfo__cpu_features__flags"].values:
+            for flags in dataframe["hwinfo__cpu_features__flags"].values:
                 for flag in flags:
                     if f"flag__{flag}" not in flags_columns:
                         flags_columns.append(f"flag__{flag}")


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/datasets/issues/53

## This introduces a breaking change

- No

## This Pull Request implements

Fix key for processed inspection runs dataframe which causes a `KeyError: '__hwinfo__cpu_features__flags'` when running the [`AmunInspectionAnalysis2021-02-09`](https://github.com/thoth-station/datasets/blob/master/notebooks/thoth-performance-dataset/AmunInspectionAnalysis2021-02-09.ipynb) notebook from the `datasets` repository.